### PR TITLE
Fix bug with node/browserify style requires

### DIFF
--- a/dist/angular-dc.js
+++ b/dist/angular-dc.js
@@ -8,7 +8,7 @@
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.
-        module.exports = factory();
+        module.exports = factory;
     } else {
         root['angularDc'] = factory(root.angular, root.dc, root._, root.d3);
     }


### PR DESCRIPTION
This is a proposed fix to #42. Basically, for Node/Browserify-style modules, we want to export the `factory` function so that globals `angular`, `dc`, `_`, and `d3` can be passed in by the caller, rather than calling the  `factory` with no arguments, which guarantees that they are `undefined`.