### PR TITLE
Increased timeout for waiting for the data to be potentially loaded

### DIFF
--- a/src/angular-dc.js
+++ b/src/angular-dc.js
@@ -184,11 +184,11 @@ angularDc.directive('dcChart', ['$timeout',
                         chart.render();
                     }
                 });
-                // if after 4 second we still get exceptions, we should raise them
+                // if after 60 seconds we still get exceptions, we should raise them
                 // to help debugging. $timeout will trigger another round of check.
                 $timeout(function() {
                     printExceptions = true;
-                }, 2000);
+                }, 60000);
 
             }
         };


### PR DESCRIPTION
…from 2 to 60 seconds so that server-fetched chart data gets time to load on slow connections
