### PR TITLE
Fix Package.json to use it as a module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "angular",
     "dc"
   ],
+  "main":"dist/angular-dc.js",
   "homepage": "https://github.com/TomNeyland/angular-dc",
   "bugs": "https://github.com/TomNeyland/angular-dc/issues",
   "author": {


### PR DESCRIPTION
This PR enables NodeJs to be able to find 'angular-dc' as a module.

Example:
```js
require('angular-dc');
```